### PR TITLE
ci: Add write permission to release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"


### PR DESCRIPTION
This change grants the write permission to the `create-release.yml` workflow. We assume that this allows the workflow to create a release.

See: https://github.com/softprops/action-gh-release/issues/236#issue-1258868166