### PR TITLE
ci: Correct version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-version = "0.1.0"
+version = "0.0.0"
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_files = [
@@ -11,7 +11,7 @@ changelog_file = "docs/CHANGELOG.md"
 
 [tool.poetry]
 name = "pyper"
-version = "0.1.0"
+version = "0.0.0"
 description = "Pyper is a Python package that offers configuration management capabilities like the Viper package in Golang."
 authors = ["Leo Schleier <43878374+leoschleier@users.noreply.github.com>"]
 license = "MIT"

--- a/src/pyper/__version__.py
+++ b/src/pyper/__version__.py
@@ -1,2 +1,2 @@
 """Version information for pyper."""
-__version__ = "0.1.0"
+__version__ = "0.0.0"


### PR DESCRIPTION
After setting the version number of the initial commit https://github.com/leoschleier/pyper/commit/87a68d5223e60380e6e41227111c12279a087156 to `v0.0.0`, we also set all version numbers to `0.0.0` to enable a proper version bump before the first release.