### PR TITLE
ci: Adjust publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,6 +28,6 @@ jobs:
         poetry install
     - name: Build and publish
       env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: |
         ./scripts/publish

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,2 +1,3 @@
 # Publish to PyPI using POETRY_PYPI_TOKEN_PYPI from the environment
-poetry publish --build -r pyper
+poetry config pypi-token.pypi $PYPI_TOKEN
+poetry publish --build


### PR DESCRIPTION
This change adjusts how Poetry is set up with the PyPI token. Instead of setting an environment variable, we now try explicitly setting the token in the config. Additionally, we add a manual pipeline trigger for `python-publish.yml` to facilitate troubleshooting as long as the release process has not yet been set up correctly.