### PR TITLE
ci: Allow execution of publish script

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,6 @@ jobs:
         poetry install
     - name: Build and publish
       env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: |
         ./scripts/publish

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,3 +1,2 @@
 # Publish to PyPI using POETRY_PYPI_TOKEN_PYPI from the environment
-poetry config pypi-token.pypi $PYPI_TOKEN
 poetry publish --build


### PR DESCRIPTION
This change enables the publication workflow to run the publish script. This is being achieved by executing the following command locally:

```bash
git update-index --chmod=+x ./scripts/publish
```

The previous PR https://github.com/leoschleier/pyper/pull/8#issue-1920798348 didn't solve the initial issue. Therefore, we switch back to using the environment variable to set the PyPI token for Poetry.