### PR TITLE
refactor: Rename package and reset version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Test data
+!tests/data/.env

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,0 @@
-## v0.1.0 (2023-10-01)
-
-### Feat
-
-- Add loading of environment variables from .env file (#3)
-
-## v0.0.0 (2023-09-09)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# pyper
+# pit-viper
 
-Pyper is a Python package that offers configuration management capabilities
+Pit-Viper is a Python package that offers configuration management capabilities
 like the Viper package in Golang.
 
 ## Table of Contents
@@ -13,24 +13,24 @@ like the Viper package in Golang.
 
 ## Installation
 
-You can install pyper using pip:
+You can install `pit-viper` using `pip`:
 
 ```bash
-pip install pyper
+pip install pit-viper
 ```
 
 ## Usage
 
 ### Environment Variables
 
-The `pyper` package provides the `auto_env` function that loads environment
+The `pit-viper` package provides the `auto_env` function that loads environment
 variables from a `.env` file. The function returns a `dict` of all existing
 environment variables.
 
 ```python
-import pyper
+from pit import viper
 
-env = pyper.auto_env()
+env = viper.auto_env()
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-version = "0.1.0"
+version = "0.0.0"
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_files = [
@@ -11,7 +11,7 @@ changelog_file = "docs/CHANGELOG.md"
 
 [tool.poetry]
 name = "pit-viper"
-version = "0.1.0"
+version = "0.0.0"
 description = "Pit-Viper is a Python package that offers configuration management capabilities like the Viper package in Golang."
 authors = ["Leo Schleier <43878374+leoschleier@users.noreply.github.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,25 +4,25 @@ name = "cz_conventional_commits"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",
-    "src/pyper/__version__.py",
+    "src/pit/viper/__version__.py",
 ]
 changelog_file = "docs/CHANGELOG.md"
 
 
 [tool.poetry]
-name = "pyper"
+name = "pit-viper"
 version = "0.1.0"
-description = "Pyper is a Python package that offers configuration management capabilities like the Viper package in Golang."
+description = "Pit-Viper is a Python package that offers configuration management capabilities like the Viper package in Golang."
 authors = ["Leo Schleier <43878374+leoschleier@users.noreply.github.com>"]
 license = "MIT"
-keywords = ["pyper"]
+keywords = ["pit-viper"]
 readme = "docs/README.md"
-homepage = "https://github.com/leoschleier/pyper"
+homepage = "https://github.com/leoschleier/pit-viper"
 # See: https://pypi.org/classifiers/
 classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
-packages = [{include = "pyper", from = "src"}]
+packages = [{include = "pit", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/src/pit/__init__.py
+++ b/src/pit/__init__.py
@@ -1,0 +1,1 @@
+"""Pit namespace package."""

--- a/src/pit/viper/__init__.py
+++ b/src/pit/viper/__init__.py
@@ -1,4 +1,4 @@
-"""Pyper offers configuration management capabilities.
+"""Pit-viper offers configuration management capabilities.
 
 This package currently provides one main function, `auto_env`,
 which reads a `.env` file and sets the corresponding environment
@@ -6,12 +6,12 @@ variables in the current process. This can be useful for configuring
 applications or scripts that rely on environment variables.
 
 Usage:
-    >>> from pyper import auto_env
-    >>> auto_env()
+    >>> from pit import viper
+    >>> viper.auto_env()
 
 For more information, see the documentation for the `auto_env`
 function.
 """
-from pyper.env import auto_env
+from pit.viper.env import auto_env
 
 __all__ = ["auto_env"]

--- a/src/pit/viper/__version__.py
+++ b/src/pit/viper/__version__.py
@@ -1,0 +1,2 @@
+"""Version information for pit-viper."""
+__version__ = "0.1.0"

--- a/src/pit/viper/__version__.py
+++ b/src/pit/viper/__version__.py
@@ -1,2 +1,2 @@
 """Version information for pit-viper."""
-__version__ = "0.1.0"
+__version__ = "0.0.0"

--- a/src/pit/viper/env.py
+++ b/src/pit/viper/env.py
@@ -29,8 +29,8 @@ def auto_env(
     Parameters
     ----------
     path : Path | None, optional
-        Path to the `.env` file. If not set, `pyper` will try to find
-        the file in the current working directory, by default None
+        Path to the `.env` file. If not set, `pit-viper` will try to
+        find the file in the current working directory, by default None
     overwrite : bool, optional
         Whether or not to overwrite existing environment variables with
         the variables from the `.env` file, by default False

--- a/src/pyper/__version__.py
+++ b/src/pyper/__version__.py
@@ -1,2 +1,0 @@
-"""Version information for pyper."""
-__version__ = "0.1.0"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test cases for the `pyper` package."""
+"""Test cases for the `pit-viper` package."""

--- a/tests/data/.env
+++ b/tests/data/.env
@@ -1,0 +1,4 @@
+TEST_VAR = "' "test_value    "'   "
+
+
+FOO = "bar"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 import py
 import pytest
-
-from pyper import env
+from pit.viper import env
 
 _TEST_DOTENV_PATH = Path(__file__).parent / "data" / ".env"
 


### PR DESCRIPTION
The initial name of the present package (`pyper`) had already been taken. Therefore, we decide to create a namespace package called `pit-viper`.