### PR TITLE
chore: Add pyright config and resolve issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,20 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 
+[tool.black]
+line-length = 79
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "strict"
+include = ["src", "tests"]
+pythonVersion = "3.11"
+
 [tool.ruff]
 select = ["ALL"]
-ignore = ["ANN101", "ANN102"]  # Type annotations for 'self' and 'cls'
 fixable = ["ALL"]
-fix = false
+fix = true
 line-length = 79
 target-version = "py311"
 
@@ -52,10 +61,6 @@ convention = "numpy"
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E401"]  # Unused import
 "tests/*" = ["S101"]  # Use of assert detected
-
-
-[tool.black]
-line-length = 79
 
 
 [tool.pytest.ini_options]

--- a/src/pit/viper/env.py
+++ b/src/pit/viper/env.py
@@ -1,6 +1,7 @@
 """Load environment variables from a `.env` file."""
 import os
 from pathlib import Path
+from typing import Self
 
 _EQUALS = "="
 _NEW_LINE = "\n"
@@ -11,9 +12,9 @@ _ENCLOSING_CHARS = f" \"'{_NEW_LINE}"
 class UnsupportedFileFormatError(Exception):
     """Raised when the file format is not supported."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self: Self, path: Path) -> None:
         """Initialize the exception."""
-        super().__init__(f"Unsupported file format: {path.suffix()}")
+        super().__init__(f"Unsupported file format: {path.suffix}")
 
 
 def auto_env(
@@ -73,7 +74,7 @@ def _populate_env(*, path: Path, overwrite: bool = False) -> None:
             _set_variable(key=k, value=v, overwrite=overwrite)
 
 
-def _set_variable(key: str, value: str, *, overwrite: bool = False) -> str:
+def _set_variable(key: str, value: str, *, overwrite: bool = False) -> None:
     """Set an environment variable."""
     if overwrite:
         os.environ[key] = value

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,7 +2,7 @@
 import os
 from pathlib import Path
 
-import py
+import py  # pyright: ignore [reportMissingTypeStubs]
 import pytest
 from pit.viper import env
 
@@ -10,7 +10,7 @@ _TEST_DOTENV_PATH = Path(__file__).parent / "data" / ".env"
 
 
 @pytest.fixture(autouse=True)
-def _prepare_env() -> None:
+def _prepare_env() -> None:  # pyright: ignore [reportUnusedFunction]
     """Prepare the environment for testing."""
     os.environ.pop("FOO", None)
     os.environ.pop("TEST_VAR", None)
@@ -46,7 +46,7 @@ def test_auto_env_with_overwrite() -> None:
     assert e["TEST_VAR"] == "test_value"
 
 
-def test_auto_env_with_non_existing_path(tmpdir: py.path.local) -> None:
+def test_auto_env_with_non_existing_path(tmpdir: py.path.LocalPath) -> None:
     """Test the `auto_env` function with a non-existing path.
 
     We expect that the function still returns a dictionary of


### PR DESCRIPTION
In this change, we add a project-specific `pyright` config to `pyproject.toml`. All `pyright` issues are resolved or ignored where appropriate.