### PR TITLE
ci: Replace automatic pipeline trigger with manual

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,9 +1,7 @@
 name: Bump version and create release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
We remove the release-workflow trigger "on push to main" in order to avoid creating a new release whenever a feature or fix is pushed to main. From now on, new releases are created by triggering the `create-release` workflow manually.