### PR TITLE
ci: Add script for setting up pre-commit hook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,4 +85,6 @@ their [documentation](https://python-poetry.org/docs).
 The `pit-viper` package is intended to be
 [PEP 561](https://peps.python.org/pep-0561/) compatible. For this reason, we
 use a pre-commit hook that validates the code on every commit. The code
-validation includes checks with Black, Ruff, Mypy, and Pyright.
+validation runs tests and performs checks using Ruff, Mypy, and Pyright.
+Execute `scripts/setup` to add the validation as your pre-commit hook for this
+project.

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source scripts/validate 

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Parent path (also resolving symlinks)
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+git_hooks_path=$parent_path/../.git/hooks
+
+# Add pre-commit hook
+ln -s -f $parent_path/hooks/pre-commit $git_hooks_path/pre-commit

--- a/scripts/validate
+++ b/scripts/validate
@@ -18,3 +18,5 @@ echo "Mypy passed."
 pyright .
 echo "Pyright passed."
 
+pytest .
+echo "Pytest passed."


### PR DESCRIPTION
We add the script `scripts/setup` which, when executed, adds a pre-configured code validation as the pre-commit hook of the present project.