### PR TITLE
feat: Use env prefix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ like the Viper package in Golang.
 ## Installation
 
 You can install `pit-viper` using `pip`:
- 
+
 ```bash
 pip install pit-viper
 ```
@@ -33,12 +33,14 @@ from pit import viper
 env = viper.auto_env()
 ```
 
-We recommend accessing your environment variables via `viper.get`. 
+We recommend accessing your environment variables via `viper.get`.
 
 ```python
 from pit import viper
 
+# Bind environment variables
 viper.auto_env()
+
 bar = viper.get("foo")
 ```
 
@@ -47,6 +49,20 @@ front.
 
 **Note**: Changes to the environment following the first import of `pit-viper`
 will not be reflected in the package's record of environment variables.
+
+Prefixes are commonly being used to prevent name collisions in environment
+variables. You can specify a prefix as follows:
+
+```python
+from pit import viper
+
+viper.set_env_prefix("pf")
+
+# Bind environment variables 
+viper.auto_env() # PF_FOO = "bar" 
+
+bar = viper.get("foo") # "bar"
+```
 
 ### Config Files
 

--- a/src/pit/viper/__init__.py
+++ b/src/pit/viper/__init__.py
@@ -27,7 +27,7 @@ from pit.viper._config import (
     set_config_type,
 )
 from pit.viper._config import set_conf as set  # noqa: A001
-from pit.viper._env import UnsupportedFileFormatError, auto_env
+from pit.viper._env import UnsupportedFileFormatError, auto_env, set_env_prefix
 
 __all__ = [
     "auto_env",
@@ -37,5 +37,6 @@ __all__ = [
     "set_config_name",
     "set_config_path",
     "set_config_type",
+    "set_env_prefix",
     "UnsupportedFileFormatError",
 ]

--- a/src/pit/viper/_config.py
+++ b/src/pit/viper/_config.py
@@ -66,7 +66,8 @@ def get_conf(key: str, default: Any = None) -> Any:
         Value for the key.
     """
     if _env.is_env_enabled():
-        env_value = os.environ.get(key)
+        env_key = f"{_env.get_env_prefix()}{key.upper()}"
+        env_value = os.environ.get(env_key)
         if env_value is not None:
             return env_value
 

--- a/src/pit/viper/_env.py
+++ b/src/pit/viper/_env.py
@@ -6,6 +6,7 @@ _EQUALS = "="
 _NEW_LINE = "\n"
 _ENCLOSING_CHARS = f" \"'{_NEW_LINE}"
 
+_env_prefix = ""
 _env_enabled = False
 
 
@@ -68,6 +69,26 @@ def is_env_enabled() -> bool:
     been called.
     """
     return _env_enabled
+
+
+def set_env_prefix(prefix: str) -> None:
+    """Set a prefix for environment variables.
+
+    The prefix will be added to the key used for accessing environment
+    variables.
+
+    Parameters
+    ----------
+    prefix : str
+        Prefix to add to environment variables.
+    """
+    global _env_prefix  # noqa: PLW0603
+    _env_prefix = prefix.upper()
+
+
+def get_env_prefix() -> str:
+    """Get the prefix for environment variables."""
+    return f"{_env_prefix}_" if _env_prefix else ""
 
 
 def _populate_env(*, path: Path, overwrite: bool = False) -> None:

--- a/tests/data/.env
+++ b/tests/data/.env
@@ -1,4 +1,5 @@
 TEST_VAR = "' "test_value    "'   "
 
 
-FOO = "bar"
+FOO = "env-bar"
+TEST_FOO = "env-test-bar"

--- a/tests/data/config/config.json
+++ b/tests/data/config/config.json
@@ -1,5 +1,5 @@
 {
-    "foo": "bar",
+    "foo": "config-bar",
     "test": {
         "nested": {
             "a": 0,

--- a/tests/data/config/config.toml
+++ b/tests/data/config/config.toml
@@ -1,4 +1,4 @@
-foo = "bar"
+foo = "config-bar"
 
 [test]
 [test.nested]

--- a/tests/data/config/config.yaml
+++ b/tests/data/config/config.yaml
@@ -1,4 +1,4 @@
-foo: bar
+foo: config-bar
 
 test:
   nested:

--- a/tests/test__io.py
+++ b/tests/test__io.py
@@ -11,7 +11,7 @@ CONFIG_TOML: Final = CONFIG_DIR / "config.toml"
 CONFIG_YAML: Final = CONFIG_DIR / "config.yaml"
 
 EX_CONFIG = {
-    "foo": "bar",
+    "foo": "config-bar",
     "test": {
         "nested": {
             "a": 0,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ CONFIG_NAME = "config"
 CONFIG_TYPE = "toml"
 
 EX_CONFIG = {
-    "foo": "bar",
+    "foo": "config-bar",
     "test.nested.a": 0,
     "test.nested.b": 1.1,
     "test.nested.c": True,
@@ -58,12 +58,20 @@ def test_config_env_hierarchy() -> None:
     viper.set_config_name(CONFIG_NAME)
     viper.set_config_type(CONFIG_TYPE)
 
-    viper.set("FOO", "default bar")
+    viper.set("foo", "default bar")
 
     viper.auto_env(path=config.TEST_DOTENV_PATH, overwrite=True)
     viper.load_config()
 
     # Environment variables should overwrite config variables.
-    # Therefore, we expect the value of `foo` to be `bar` which is the
-    # value specified in the .env file.
-    assert viper.get("foo") == "bar"
+    # Therefore, we expect the value of `foo` to be `env-bar` which is
+    # the value specified in the .env file.
+    assert viper.get("foo") == "env-bar"
+
+
+def test_env_prefix() -> None:
+    """Test setting an environment variable prefix."""
+    viper.set_env_prefix("test")
+    viper.auto_env(path=config.TEST_DOTENV_PATH, overwrite=True)
+
+    assert viper.get("foo") == "env-test-bar"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -34,7 +34,7 @@ def test_auto_env_with_overwrite() -> None:
 
     e = viper.auto_env(path=config.TEST_DOTENV_PATH, overwrite=True)
 
-    assert e["FOO"] == "bar"
+    assert e["FOO"] == "env-bar"
     assert e["TEST_VAR"] == "test_value"
 
 


### PR DESCRIPTION
We allow the user to specify a prefix for environment variables which is considered when accessing environment variables. This functionality can be used as follows:

```python
from pit import viper

viper.set_env_prefix("pf")

# Bind environment variables 
viper.auto_env() # PF_FOO = "bar" 

bar = viper.get("foo") # "bar"
```

Additionally, we now convert the key passed to `viper.get` to upper case when accessing environment variables.
