### PR TITLE
feat: Add replacer for env keys

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,23 @@ viper.auto_env() # PF_FOO = "bar"
 bar = viper.get("foo") # "bar"
 ```
 
+We provide you with the option to overwrite env keys when querying
+environment variables. For example, you might want to overwrite a `.`
+used for retrieving parameters from a config with a `_` when accessing
+environment variables. This can be useful for creating a mapping between
+env keys and config keys.
+
+```python
+from pit import viper
+
+# Bind environment variables 
+viper.auto_env() # MY_FOO = "bar" 
+
+viper.set_env_key_replacer({".": "_"})
+
+bar = viper.get("my.foo") # "bar"
+```
+
 ### Config Files
 
 Config files are another config source for `pit-viper`. The package supports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ venvPath = "."
 venv = ".venv"
 typeCheckingMode = "strict"
 include = ["src", "tests"]
+ignore = ["tests/conftest.py"]
 pythonVersion = "3.11"
 
 [tool.ruff]
@@ -75,7 +76,7 @@ convention = "numpy"
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E401"]  # Unused import
 "tests/*" = ["S101"]  # Use of assert detected
-
+"tests/conftest.py" = ["SLF001"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/pit/viper/__init__.py
+++ b/src/pit/viper/__init__.py
@@ -27,7 +27,12 @@ from pit.viper._config import (
     set_config_type,
 )
 from pit.viper._config import set_conf as set  # noqa: A001
-from pit.viper._env import UnsupportedFileFormatError, auto_env, set_env_prefix
+from pit.viper._env import (
+    UnsupportedFileFormatError,
+    auto_env,
+    set_env_key_replacer,
+    set_env_prefix,
+)
 
 __all__ = [
     "auto_env",
@@ -37,6 +42,7 @@ __all__ = [
     "set_config_name",
     "set_config_path",
     "set_config_type",
+    "set_env_key_replacer",
     "set_env_prefix",
     "UnsupportedFileFormatError",
 ]

--- a/src/pit/viper/_config.py
+++ b/src/pit/viper/_config.py
@@ -1,5 +1,4 @@
 """Load config from file."""
-import os
 from pathlib import Path
 from typing import Any
 
@@ -65,11 +64,9 @@ def get_conf(key: str, default: Any = None) -> Any:
     Any
         Value for the key.
     """
-    if _env.is_env_enabled():
-        env_key = f"{_env.get_env_prefix()}{key.upper()}"
-        env_value = os.environ.get(env_key)
-        if env_value is not None:
-            return env_value
+    env_value = _env.get_env(key)
+    if env_value is not None:
+        return env_value
 
     keys = key.split(".")
     config_value = _config

--- a/src/pit/viper/_env.py
+++ b/src/pit/viper/_env.py
@@ -96,8 +96,8 @@ def get_env_prefix() -> str:
 def set_env_key_replacer(oldnew: dict[str, str]) -> None:
     """Set replacer to replace keys and substrings of keys.
 
-    Replacements are being performed when retrieving environment
-    variables.
+    Replacements are being performed in the order defined in `oldnew`,
+    when retrieving environment variables.
 
     Parameters
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,27 @@
 import os
 
 import pytest
+from pit import viper
+
+# pyright: reportGeneralTypeIssues=false, reportUnknownMemberType=false
 
 
 @pytest.fixture(autouse=True)
 def _prepare_env() -> None:  # pyright: ignore [reportUnusedFunction]
     """Prepare the environment for testing."""
     os.environ.pop("FOO", None)
+    os.environ.pop("TEST_FOO", None)
     os.environ.pop("TEST_VAR", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_viper() -> None:  # pyright: ignore [reportUnusedFunction]
+    """Reset viper's state."""
+    viper._config._config_path = None
+    viper._config._config_name = ""
+    viper._config._config_type = ""
+    viper._config._config = {}
+
+    viper._env._env_prefix = ""
+    viper._env._env_enabled = False
+    viper._env._oldnew = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,3 +75,18 @@ def test_env_prefix() -> None:
     viper.auto_env(path=config.TEST_DOTENV_PATH, overwrite=True)
 
     assert viper.get("foo") == "env-test-bar"
+
+
+def test_env_key_replacer() -> None:
+    """Test replacing keys and substrings of keys."""
+    viper.set_env_key_replacer({"old-foo": "foo", ".": "_"})
+    viper.auto_env(path=config.TEST_DOTENV_PATH, overwrite=True)
+
+    assert viper.get("foo") == "env-bar"
+    assert viper.get("old-foo") == "env-bar"
+
+    assert viper.get("test_var") == "test_value"
+    assert viper.get("test.var") == "test_value"
+
+    assert viper.get("test_foo") == "env-test-bar"
+    assert viper.get("test.foo") == "env-test-bar"


### PR DESCRIPTION
We add the option of replacing env keys and substrings of env keys. This functionality can be used to create a mapping between config keys and env keys. Example:

```python
from pit import viper

# Bind environment variables 
viper.auto_env() # MY_FOO = "bar" 

viper.set_env_key_replacer({".": "_"})

bar = viper.get("my.foo") # "bar"
```
